### PR TITLE
fix dof to always be the same for chi2 result

### DIFF
--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -1,8 +1,8 @@
 import numpy as np
-from pqm import pqm_pvalue
+from pqm import pqm_pvalue, pqm_chi2
 
 
-def test():
+def test_pass_pvalue():
     new = []
     for _ in range(100):
         y_samples = np.random.normal(size=(500, 50))
@@ -11,3 +11,36 @@ def test():
         new.append(pqm_pvalue(x_samples, y_samples))
 
     assert np.abs(np.mean(new) - 0.5) < 0.15
+
+
+def test_pass_chi2():
+    new = []
+    for _ in range(100):
+        y_samples = np.random.normal(size=(500, 50))
+        x_samples = np.random.normal(size=(250, 50))
+
+        new.append(pqm_chi2(x_samples, y_samples, num_refs=100))
+    new = np.array(new)
+    assert np.abs(np.mean(new[:, 0]) / 99 - 1) < 0.15
+
+
+def test_fail_pvalue():
+    new = []
+    for _ in range(100):
+        y_samples = np.random.normal(size=(500, 50))
+        x_samples = np.random.normal(size=(250, 50)) + 0.5
+
+        new.append(pqm_pvalue(x_samples, y_samples))
+
+    assert np.mean(new) < 1e-3
+
+
+def test_fail_chi2():
+    new = []
+    for _ in range(100):
+        y_samples = np.random.normal(size=(500, 50))
+        x_samples = np.random.normal(size=(250, 50)) + 0.5
+
+        new.append(pqm_chi2(x_samples, y_samples, num_refs=100))
+    new = np.array(new)
+    assert np.mean(new[:, 0]) / 99 > 10


### PR DESCRIPTION
Had an idea to get chi2 values with a fixed dof. I rescale the chi2 value with dof_1 to a new chi2 distribution with dof_2 by ensuring that they both have the same cumulative probability. This makes sense to me, but we should make sure it's statistically sound before merging. With this, we would always have the same dof.

Closes #6 